### PR TITLE
OpenWRT local compiling support.

### DIFF
--- a/Makefile.openwrt_local
+++ b/Makefile.openwrt_local
@@ -1,0 +1,67 @@
+CFLAGS=-ffunction-sections -fdata-sections -Wno-unused-result -I./src -I./libs -I./libs/miniupnpc -I./libs/libnatpmp -I./libs/zlib -D NO_GZIP=1 -D GNB_LINUX_BUILD=1
+CLI_LDFLAGS=-Wl,--gc-sections -L/usr/lib
+GNB_ES_LDFLAGS=-Wl,--gc-sections -L/usr/lib
+
+
+ifeq ($(DEBUG),1)
+CFLAGS += -g
+else
+CFLAGS += -O2
+CLI_LDFLAGS    += -s
+GNB_ES_LDFLAGS += -s
+endif
+
+
+GNB_CRYPTO=gnb_crypto
+GNB_CTL=gnb_ctl
+GNB_ES=gnb_es
+GNB_CLI=gnb
+
+
+include Makefile.inc
+
+
+GNB_CLI_OBJS =                             \
+       ./src/cli/gnb.o                     \
+       ./src/gnb_argv.o                    \
+       ./src/unix/unix_platform.o          \
+       ./src/linux/gnb_drv_linux.o
+
+GNB_ES_OBJS += ./src/unix/unix_platform.o
+
+all:${GNB_CLI} ${GNB_CRYPTO} ${GNB_ES} ${GNB_CTL}
+
+
+$(GNB_CTL): $(GNB_CTL_OBJS)
+	${CC} -o ${GNB_CTL} ${GNB_CTL_OBJS} ${CLI_LDFLAGS}
+
+
+$(GNB_ES): $(GNB_ES_OBJS) ${CRYPTO_OBJS} ${MINIUPNP_OBJS} ${LIBNATPMP_OBJS}
+	${CC} -o ${GNB_ES} ${GNB_ES_OBJS} ${CRYPTO_OBJS} ${MINIUPNP_OBJS} ${LIBNATPMP_OBJS} ${GNB_ES_LDFLAGS}
+
+
+$(GNB_CRYPTO): $(CRYPTO_OBJS) ./src/cli/gnb_crypto.o
+	${CC} -o ${GNB_CRYPTO} ./src/cli/gnb_crypto.o ${CRYPTO_OBJS} ${CLI_LDFLAGS}
+
+
+$(GNB_CLI): $(GNB_OBJS) $(GNB_CLI_OBJS) $(GNB_PF_OBJS) ${CRYPTO_OBJS} ${ZLIB_OBJS}
+	${CC} -o ${GNB_CLI} ${GNB_OBJS} ${GNB_CLI_OBJS} ${GNB_PF_OBJS} ${CRYPTO_OBJS} ${ZLIB_OBJS} ${CLI_LDFLAGS}
+
+
+%.o:%.c
+	${CC} ${CFLAGS} -c -o $@ $<
+
+
+install:${GNB_CLI} ${GNB_CRYPTO} ${GNB_ES} ${GNB_CTL}
+	mkdir -p         ./bin/
+	cp ${GNB_CLI}    ./bin/
+	cp ${GNB_CTL}    ./bin/
+	cp ${GNB_CRYPTO} ./bin/
+	cp ${GNB_ES}     ./bin/
+
+
+clean:
+	find . -name "*.o" -exec rm -f {} \;
+	rm -f ${GNB_CLI} ${GNB_CRYPTO} ${GNB_ES} ${GNB_CTL}
+	rm -f core core.*
+	rm -f *.exe

--- a/README.md
+++ b/README.md
@@ -292,6 +292,16 @@ i|0|172.104.91.191|9001
 Note:charleschan<hollidgelongsun157@gmail.com>(https://github.com/orgs/opengnb/people/charleschan2006-alias) made great efforts for OpenGNB porting to OpenWRT platform and provides technical supoort.
 GNB supports the OpenWRT platform and needs to be compiled by the user.
 
+## GNB local compiling on OpenWRT
+
+You can compile locally on OpenWRT if you have GCC installed. Tested on an Intel box with OpenWRT 25 installed.
+**Note:** You may need to install `kmod-tun` if you haven't installed it previously.
+
+```
+git clone https://github.com/gnbdev/opengnb.git
+cd opengnb
+make -f Makefile.openwrt_local install
+```
 
 ## GNB on Linux distributions
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -291,6 +291,16 @@ i|0|172.104.91.191|9001
 ## GNB在OpenWRT上
 Note:注：charleschan<hollidgelongsun157@gmail.com>(https://github.com/orgs/opengnb/people/charleschan2006-alias) 为 OpenGNB 移植到 OpenWRT 平台做出了巨大努力，并提供了技术支持。
 
+## GNB在OpenWRT上本地编译
+
+如果你的OpenWRT本地安装有GCC，你可以在本地编译OpenWRT。在一台安装有OpenWRT 25的Intel主机上测试成功。
+**注意：** 你需要安装并启用 `kmod-tun` 内核模块。
+
+```
+git clone https://github.com/gnbdev/opengnb.git
+cd opengnb
+make -f Makefile.openwrt_local install
+```
 
 ## GNB 在 Linux 发行版上
 


### PR DESCRIPTION
支持OpenWRT本地编译GNB。

Makefile文件从Makefile.linux复制，解决原openwrt Makefile的zlib等库依赖本地库等问题。唯一修改是去掉了-lpthread这个链接flag。因为OpenWRT把pthread库包装到glibc了。

修改README中英文文件。

没有测试交叉编译，所以加了_local后缀。可能也能支持交叉编译，但没有环境可以测试。
