### PR TITLE
修复堆释放后的内存记账

### DIFF
--- a/src/gnb_alloc.c
+++ b/src/gnb_alloc.c
@@ -67,6 +67,7 @@ void* gnb_heap_alloc(gnb_heap_t *gnb_heap, uint32_t size) {
         printf("gnb_heap_alloc error  malloc false\n");
         return NULL;
     }
+    fragment->size = size;
     fragment->idx = gnb_heap->fragment_nums;
     gnb_heap->fragment_list[ gnb_heap->fragment_nums ] = fragment;
     gnb_heap->fragment_nums++;
@@ -95,22 +96,18 @@ void gnb_heap_free(gnb_heap_t *gnb_heap, void *p){
         //发生错误了
         return;
     }
-    if ( 1 == gnb_heap->fragment_nums ) {
-        if ( fragment->idx != last_fragment->idx ) {
-            //发生错误了
-            return;
-        }
-        goto finish;
+    if ( 1 == gnb_heap->fragment_nums && fragment->idx != last_fragment->idx ) {
+        //发生错误了
+        return;
     }
-    if ( last_fragment->idx == fragment->idx ) {
-        goto finish;
-    }
+
     gnb_heap->alloc_byte -= fragment->size;
     gnb_heap->ralloc_byte -= (sizeof(gnb_heap_fragment_t)+fragment->size);
-    last_fragment->idx = fragment->idx;
-    gnb_heap->fragment_list[last_fragment->idx] = last_fragment;
 
-finish:
+    if ( last_fragment->idx != fragment->idx ) {
+        last_fragment->idx = fragment->idx;
+        gnb_heap->fragment_list[last_fragment->idx] = last_fragment;
+    }
 
     gnb_heap->fragment_nums--;
     free(fragment);


### PR DESCRIPTION
## 变更内容

堆分配器现在会记录每个分片的实际大小，并在释放任意位置的分片后同步扣减已分配字节数和保留字节数。修改前，释放唯一分片或尾部分片不会更新统计值，释放非尾部分片还会读取未初始化的大小，导致内存记账持续偏大或出现异常数值。

## 根因与风险

根因是分配路径没有初始化 `gnb_heap_fragment_t.size`，而释放路径又在两个提前跳转分支中绕过了统一记账。修复保持原有交换删除逻辑和接口不变，仅恢复 `alloc_byte`、`ralloc_byte` 与当前存活分片的一致性；不涉及协议、配置格式或网络行为。

## 验证

- Windows MSYS2 MinGW64：`make -f Makefile.mingw_x86_64 clean`，随后执行 `make -f Makefile.mingw_x86_64 CC=gcc WINDRES=windres`。`gnb.exe`、`gnb_crypto.exe`、`gnb_ctl.exe`、`gnb_es.exe` 均构建成功。
- Windows 命令行冒烟：设置当前进程兼容层为 `RunAsInvoker` 后执行 `gnb.exe --help`，帮助信息正常输出，退出码为 `0`。
- 确定性红绿回归：测试分配器以 `0xA5` 填充分配内存。修改前，唯一分片、尾部分片和非尾部分片释放场景共出现 `10` 项记账失败；修改后同一组检查全部通过。
- WSL Ubuntu：`make -f Makefile.linux clean`，随后执行 `make -f Makefile.linux`，构建成功。
- 差异检查：`git diff --check` 通过。

## 运行时行为

连续分配、释放唯一分片、释放尾部分片、释放非尾部分片以及再次分配后，两个堆字节计数器都会回到对应存活分片的准确总和。

## 限制

仓库当前没有自动化测试套件，本次使用的确定性回归程序为本地临时验证工具，未纳入提交。该变更不涉及网页或前端路由，因此浏览器测试不适用。

## 关联 Issue

无。
