### PR TITLE
修复参数列表序列化的终止符越界

### DIFF
--- a/src/gnb_arg_list.c
+++ b/src/gnb_arg_list.c
@@ -52,7 +52,7 @@ int gnb_arg_list_to_string(gnb_arg_list_t *arg_list, char *string, size_t string
     size_t copied_len = 0;
     for ( i=0; i < arg_list->argc; i++ ) {
         argv_len = strlen( arg_list->argv[i] );
-        if ( (copied_len + argv_len) > string_len ) {
+        if ( (copied_len + argv_len + 1) > string_len ) {
             break;
         }
         strncpy(p, arg_list->argv[i], string_len-copied_len);


### PR DESCRIPTION
## 变更内容

参数列表序列化现在会在复制前同时检查参数内容和最终字符串终止符所需的容量。修改前，单个 `abcd` 写入 4 字节输出时会错误返回成功，并在输出数组后一字节写入；修改后该场景返回 `-1`，精确可容纳和多参数场景保持原有结果。

## 根因与风险

`gnb_arg_list_to_string` 复制参数后会写一个空格，循环结束时再把最后一个空格替换为 `NUL`，但容量判断漏算了这个字节。本次仅在现有比较中补计一个字节，不改变函数签名、参数间空格、空列表行为或容量不足时已有的部分输出语义。

## 验证

- Windows 确定性红灯：修改前使用紧邻输出数组的 `0xA5` 哨兵运行回归程序，4 字节不足场景错误返回 `0`，哨兵被改为 `0x00`，共报告 `2` 项失败。
- Windows MinGW64 绿灯：`gcc -std=gnu11 -Wall -Wextra -Wno-sign-compare -Werror -Isrc <回归程序> src/gnb_arg_list.c -o <测试程序>`，四个边界场景全部通过。
- Windows 目标模块编译：`gcc -std=gnu11 -Wall -Wextra -Wno-sign-compare -Werror -Isrc -c src/gnb_arg_list.c -o <临时对象>`，编译成功。
- WSL Ubuntu：使用相同告警参数编译 `src/gnb_arg_list.c` 并运行同一回归程序，全部检查通过。
- 差异检查：`git diff --check` 通过。

`-Wno-sign-compare` 仅抑制 `gnb_arg_append` 中本次修改前已存在的比较告警，其余告警仍按错误处理。

## 运行时行为

5 字节输出仍可得到 `abcd\0`，两个参数仍可得到 `ab c\0`；4 字节输出和零容量输出会在任何越界写入前返回失败。

## 限制

仓库当前没有自动化测试套件，本次确定性回归程序为本地临时验证工具，未纳入提交。按本次范围约束，未使用会编译其他模块的全仓 Makefile，仅编译和运行受影响的通用参数列表模块。该变更没有网页或前端资源，浏览器测试不适用。

## 关联 Issue

无。
