### PR TITLE
修复 Hash32 同键更新的链节点替换

### DIFF
--- a/src/gnb_hash32.c
+++ b/src/gnb_hash32.c
@@ -159,12 +159,17 @@ int gnb_hash32_store(gnb_hash32_map_t *hash32_map, u_char *key, uint32_t key_len
             continue;
         }
         if ( !memcmp(kv_chain->key->data, key, key_len) ) {
-            gnb_kv32_release(hash32_map, kv_chain);
-            if ( bucket->kv_chain != kv_chain ) {
-                pre_kv_chain->nex = gnb_kv32_create(hash32_map, key, key_len, value, value_len);
-            } else {
-                bucket->kv_chain = gnb_kv32_create(hash32_map, key, key_len, value, value_len);
+            kv = gnb_kv32_create(hash32_map, key, key_len, value, value_len);
+            if ( NULL == kv ) {
+                return -1;
             }
+            kv->nex = kv_chain->nex;
+            if ( bucket->kv_chain != kv_chain ) {
+                pre_kv_chain->nex = kv;
+            } else {
+                bucket->kv_chain = kv;
+            }
+            gnb_kv32_release(hash32_map, kv_chain);
             break;
         }
         pre_kv_chain = kv_chain;


### PR DESCRIPTION
## 摘要

Hash32 同键更新现在只替换现有节点一次，不再错误进入新键追加分支。更新链头、链中或链尾节点时会保留原有后继，因此冲突桶中的其他键、`chain_len` 和 `kv_num` 均保持正确。

替换节点会在旧节点释放前完成分配；若堆碎片名额已经占满，函数返回 `-1` 并保留旧值和原链，避免部分更新。

## 风险

- 公开函数签名、键值表示和哈希算法未改变。
- 仓库内没有 `gnb_hash32_store` 的业务调用方，只有公开声明和宏包装。
- 满堆时同键更新由原来的错误成功结果改为明确失败；这是为保证旧状态不受损而接受的容量边界。
- 本轮只修改通用 Hash32 容器，没有读取或修改网络、密码学、认证和 TUN 模块。

## 验证

Windows MinGW64 目标模块严格告警编译：

```powershell
gcc -std=gnu11 -O2 -Wall -Wextra -Werror -Wno-sign-compare -Wno-unused-parameter -Isrc -c src/gnb_hash32.c -o gnb_hash32.windows.o
```

Windows 临时回归程序覆盖单键、单桶链头、链中、链尾、新键追加和 `max_fragment=4` 分配失败场景：

```powershell
gcc -std=gnu11 -O0 -g3 -Wall -Wextra -Werror -Wno-sign-compare -Wno-unused-parameter -Isrc hash32_key_update_test.c src/gnb_hash32.c src/gnb_alloc.c libs/hash/murmurhash.c -o hash32_key_update_test.exe
.\hash32_key_update_test.exe
```

WSL Ubuntu 使用相同源码执行 ASan/UBSan 回归：

```bash
gcc -std=gnu11 -O0 -g3 -Wall -Wextra -Werror -Wno-sign-compare -Wno-unused-parameter -fsanitize=address,undefined -fno-omit-frame-pointer -Isrc hash32_key_update_test.c src/gnb_hash32.c src/gnb_alloc.c libs/hash/murmurhash.c -o /tmp/hash32_key_update_test
ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 UBSAN_OPTIONS=halt_on_error=1 /tmp/hash32_key_update_test
```

两平台运行日志：

```text
gnb_heap_alloc fail heap is full
Hash32 同键更新回归通过。
```

第一行是满堆失败用例的预期日志。按本轮范围约束未执行会连带网络模块的全仓 Makefile 构建。

## 关联

关联 Issue：无。

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
