### PR TITLE
修复 Windows MinGW64 构建支持

### DIFF
--- a/Makefile.mingw_x86_64
+++ b/Makefile.mingw_x86_64
@@ -1,8 +1,21 @@
-CFLAGS=-O2 -I./src -I/usr/x86_64-w64-mingw32/include -I./libs -I./libs/wintun -I./libs/miniupnpc -I./libs/libnatpmp -I./libs/zlib -D NO_GZIP=1 -DMINIUPNP_STATICLIB -DNATPMP_STATICLIB
+ifeq ($(origin CC),default)
+CC=gcc
+endif
 
-CLI_LDFLAGS=-s -static -L/usr/x86_64-w64-mingw32/lib/ -lwsock32 -lws2_32 -liphlpapi -lpthread -lmingwex
-GNB_ES_LDFLAGS=-s -static -L/usr/x86_64-w64-mingw32/lib/ -lwsock32 -lws2_32 -liphlpapi -lpthread -lmingwex
+WINDRES ?= windres
 
+GNB_CPPFLAGS=-I./src -I./libs -I./libs/wintun -I./libs/miniupnpc -I./libs/libnatpmp -I./libs/zlib -D NO_GZIP=1 -DMINIUPNP_STATICLIB -DNATPMP_STATICLIB
+
+CLI_LDFLAGS=-static -lwsock32 -lws2_32 -liphlpapi -lpthread -lmingwex
+GNB_ES_LDFLAGS=-static -lwsock32 -lws2_32 -liphlpapi -lpthread -lmingwex
+
+ifeq ($(DEBUG),1)
+CFLAGS += -g
+else
+CFLAGS += -O2
+CLI_LDFLAGS += -s
+GNB_ES_LDFLAGS += -s
+endif
 
 GNB_CRYPTO=gnb_crypto.exe
 GNB_CTL=gnb_ctl.exe
@@ -12,6 +25,7 @@ GNB_CLI=gnb.exe
 
 include Makefile.inc
 
+.PHONY: all install clean
 
 GNB_CLI_OBJS =                             \
        ./src/cli/gnb.o                     \
@@ -27,23 +41,23 @@ all:${GNB_CLI} ${GNB_CRYPTO} ${GNB_ES} ${GNB_CTL}
 
 
 ${GNB_CTL}: ${GNB_CTL_OBJS} ./src/mingw/gnb_res.o
-	${CC} -o ${GNB_CTL} ${GNB_CTL_OBJS} ./src/mingw/gnb_res.o ${CLI_LDFLAGS}
+	${CC} -o ${GNB_CTL} ${GNB_CTL_OBJS} ./src/mingw/gnb_res.o ${LDFLAGS} ${CLI_LDFLAGS}
 
 
-${GNB_ES}: ${GNB_ES_OBJS} ${CRYPTO_OBJS} ${MINIUPNP_OBJS} ${LIBNATPMP_OBJS}
-	${CC} -o ${GNB_ES} ${GNB_ES_OBJS} ${CRYPTO_OBJS} ${MINIUPNP_OBJS} ${LIBNATPMP_OBJS} ./src/mingw/gnb_res.o ${GNB_ES_LDFLAGS}
+${GNB_ES}: ${GNB_ES_OBJS} ${CRYPTO_OBJS} ${MINIUPNP_OBJS} ${LIBNATPMP_OBJS} ./src/mingw/gnb_res.o
+	${CC} -o ${GNB_ES} ${GNB_ES_OBJS} ${CRYPTO_OBJS} ${MINIUPNP_OBJS} ${LIBNATPMP_OBJS} ./src/mingw/gnb_res.o ${LDFLAGS} ${GNB_ES_LDFLAGS}
 
 
 $(GNB_CRYPTO): $(CRYPTO_OBJS) ./src/cli/gnb_crypto.o
-	${CC} -o ${GNB_CRYPTO} ./src/cli/gnb_crypto.o ${CRYPTO_OBJS} ${CLI_LDFLAGS}
+	${CC} -o ${GNB_CRYPTO} ./src/cli/gnb_crypto.o ${CRYPTO_OBJS} ${LDFLAGS} ${CLI_LDFLAGS}
 
 
 ${GNB_CLI}: ${GNB_OBJS} ${GNB_CLI_OBJS} ${GNB_PF_OBJS} ${CRYPTO_OBJS} ${ZLIB_OBJS}
-	${CC} -o ${GNB_CLI} ${GNB_OBJS} ${GNB_CLI_OBJS} ${GNB_PF_OBJS} ${CRYPTO_OBJS} ${ZLIB_OBJS} ${CLI_LDFLAGS}
+	${CC} -o ${GNB_CLI} ${GNB_OBJS} ${GNB_CLI_OBJS} ${GNB_PF_OBJS} ${CRYPTO_OBJS} ${ZLIB_OBJS} ${LDFLAGS} ${CLI_LDFLAGS}
 
 
 %.o:%.c
-	${CC} ${CFLAGS} -c -o $@ $<
+	${CC} ${GNB_CPPFLAGS} ${CPPFLAGS} ${CFLAGS} -c -o $@ $<
 
 ./src/mingw/gnb_res.o: ./src/mingw/gnb_res.rc
 	${WINDRES} ./src/mingw/gnb_res.rc -o ./src/mingw/gnb_res.o

--- a/docs/gnb_user_manual_cn.md
+++ b/docs/gnb_user_manual_cn.md
@@ -706,11 +706,40 @@ make -f Makefile.Darwin
 
 ## Windows
 
+Windows 本机构建以 MSYS2 MINGW64 终端为支持环境。首次构建前安装 GCC、Binutils、Winpthreads 和 Make：
+
+```
+pacman -S --needed mingw-w64-x86_64-gcc mingw-w64-x86_64-binutils mingw-w64-x86_64-winpthreads make
+```
+
+默认发布构建会生成 `gnb.exe`、`gnb_crypto.exe`、`gnb_ctl.exe` 和 `gnb_es.exe`：
+
 ```
 make -f Makefile.mingw_x86_64
 ```
 
-`Makefile.mingw_x86_64` 是专门为在 Linux 下用  mingw 编译工具链编译的 Makefile，在 Windows 上也可以使用。
+调试构建保留调试符号，并关闭发布构建使用的优化和符号剥离。切换发布与调试模式前需要先清理共享对象文件：
+
+```
+make -f Makefile.mingw_x86_64 clean
+make -f Makefile.mingw_x86_64 DEBUG=1
+```
+
+安装目标把四个程序复制到 `bin/`，清理目标删除共享对象和仓库根目录中的构建结果，但保留 `bin/` 中的安装副本：
+
+```
+make -f Makefile.mingw_x86_64 install
+make -f Makefile.mingw_x86_64 clean
+```
+
+Makefile 默认使用 `gcc` 和 `windres`。Linux 交叉编译或自定义工具链可以覆盖 `CC`、`WINDRES`，并通过 `CPPFLAGS`、`LDFLAGS` 追加非标准头文件和库搜索目录。切换这些工具或标志前必须先清理，避免 GNU Make 复用由旧配置生成的对象和程序；以下两个覆盖示例相互独立：
+
+```
+make -f Makefile.mingw_x86_64 clean
+make -f Makefile.mingw_x86_64 CC=x86_64-w64-mingw32-gcc WINDRES=x86_64-w64-mingw32-windres
+make -f Makefile.mingw_x86_64 clean
+make -f Makefile.mingw_x86_64 CPPFLAGS="-I/custom/include" LDFLAGS="-L/custom/lib"
+```
 
 在 Windows 上，运行 GNB 需要安装虚拟网卡，可以在这里下载： [tap-windows](https://github.com/gnbdev/gnb_build/tree/main/if_drv/tap-windows ""downloads"")。
 


### PR DESCRIPTION
## 变更摘要

Windows 开发者现在可以在 MSYS2 MINGW64 终端直接运行默认 Makefile 命令，生成 `gnb.exe`、`gnb_crypto.exe`、`gnb_ctl.exe` 和 `gnb_es.exe`，无需额外传入编译器或资源编译器变量。

- 为 `CC` 与 `WINDRES` 提供不覆盖调用者显式配置的 Windows 默认值。
- 移除固定的 Linux 交叉工具链搜索目录，保留 `CPPFLAGS`、`LDFLAGS`、`CC` 与 `WINDRES` 覆盖入口。
- 对齐发布与 `DEBUG=1` 的优化、调试符号和符号剥离语义。
- 补齐 `gnb_es.exe` 的资源对象依赖，避免并行构建先链接后生成资源的竞态。
- 声明 `all`、`install`、`clean` 为 phony，并补充 MSYS2 安装、构建、清理和工具链切换说明。

## 风险

- Windows、Linux、发布、调试和自定义工具链仍共用源码目录中的 `.o`；切换模式、平台、编译器或搜索标志前必须执行 `clean`，中文手册已明确这一边界。
- 未在 Linux 主机使用 `x86_64-w64-mingw32-gcc` 完成真实交叉构建；本次已验证 MSYS2 MINGW64 原生构建、变量覆盖语义和 WSL Linux 原生回归。
- 仓库没有自动化测试套件；构建行为通过实际工具链、产物检查和命令行冒烟验证。

## 测试

### Windows 11 / MSYS2 MINGW64

工具链：GCC 16.1.0、GNU Binutils 2.46.1、GNU Make 4.4.1。

```sh
make -f Makefile.mingw_x86_64 clean
make -s -f Makefile.mingw_x86_64 -j4
make -f Makefile.mingw_x86_64 install
make -f Makefile.mingw_x86_64 install
make -f Makefile.mingw_x86_64 clean
make -f Makefile.mingw_x86_64 clean

make -s -f Makefile.mingw_x86_64 -j4 DEBUG=1
make -f Makefile.mingw_x86_64 clean

make -s -f Makefile.mingw_x86_64 -j4 CC=gcc WINDRES=windres
make -f Makefile.mingw_x86_64 clean
make -s -f Makefile.mingw_x86_64 -j4 CPPFLAGS=-I/tmp/opengnb-include LDFLAGS=-L/tmp/opengnb-lib
make -f Makefile.mingw_x86_64 clean
```

结果：上述构建和重复生命周期命令均以 `0` 退出；四个程序均生成。发布产物不含 `.debug_*` 段，调试产物各包含 9 个调试段；`install` 副本与根目录产物 SHA-256 一致，`clean` 删除根目录程序和共享对象并保留 `bin/` 副本。交付前已把四个 `bin/*.exe` 恢复到验证前的不存在状态。

### Windows 运行时冒烟

```powershell
$env:__COMPAT_LAYER='RunAsInvoker'
.\gnb.exe --help
```

结果：输出 OpenGNB Dev 1.6.6、协议版本 1.6.0 的帮助信息，退出码为 `0`。

### Ubuntu / WSL2

工具链：Ubuntu GCC 13.3.0、GNU Make 4.3。

```sh
wsl bash -lc 'cd /mnt/e/Projects/opengnb && make -s -f Makefile.linux -j4'
wsl bash -lc 'cd /mnt/e/Projects/opengnb && make -s -f Makefile.linux clean'
```

结果：`gnb`、`gnb_crypto`、`gnb_ctl` 和 `gnb_es` 四个 ELF 程序构建成功，清理后无根目录程序或共享对象残留。

## 审查

- 精简审查：复用、质量和效率三个维度无须修改。
- 代码审查：发现并修复 1 项 P2 文档问题，独立验证确认切换工具链或构建标志前需要先清理；无 P0/P1 残留。
- 浏览器测试：不适用，本次差异没有页面或路由。

## 关联 Issue

无。

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
