### PR TITLE
修复 Hash32 值更新并明确堆计数归零

### DIFF
--- a/check/check_additional_changes_summary_cn.html
+++ b/check/check_additional_changes_summary_cn.html
@@ -1,0 +1,477 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>check 目录追加修改说明</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #17212b;
+      --muted: #475569;
+      --line: #cbd5e1;
+      --surface: #ffffff;
+      --page: #f4f7f9;
+      --navy: #102a43;
+      --teal: #006d5b;
+      --teal-soft: #e6f5f1;
+      --amber: #7a4b00;
+      --amber-soft: #fff4d6;
+      --red: #a3261d;
+      --red-soft: #fdecea;
+      --code: #0b1825;
+    }
+
+    * { box-sizing: border-box; }
+
+    html { background: var(--page); }
+
+    body {
+      margin: 0;
+      color: var(--ink);
+      background: var(--page);
+      font-family: "Microsoft YaHei", "PingFang SC", system-ui, sans-serif;
+      font-size: 16px;
+      line-height: 1.7;
+      letter-spacing: 0;
+    }
+
+    header {
+      color: #ffffff;
+      background: var(--navy);
+      border-bottom: 5px solid #18a287;
+    }
+
+    .header-inner,
+    main {
+      width: min(1080px, calc(100% - 32px));
+      margin: 0 auto;
+    }
+
+    .header-inner { padding: 34px 0 30px; }
+
+    h1 {
+      margin: 0 0 8px;
+      font-size: 30px;
+      line-height: 1.25;
+      font-weight: 750;
+      letter-spacing: 0;
+    }
+
+    .subtitle {
+      max-width: 760px;
+      margin: 0;
+      color: #dce8f2;
+      font-size: 16px;
+    }
+
+    main { padding: 30px 0 48px; }
+
+    section {
+      margin: 0 0 34px;
+      scroll-margin-top: 16px;
+    }
+
+    h2 {
+      margin: 0 0 14px;
+      padding-bottom: 8px;
+      border-bottom: 2px solid var(--line);
+      font-size: 21px;
+      line-height: 1.35;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      margin: 0 0 8px;
+      font-size: 17px;
+      line-height: 1.4;
+      letter-spacing: 0;
+    }
+
+    p { margin: 0 0 12px; }
+
+    code {
+      font-family: Consolas, "Courier New", monospace;
+      font-size: 0.94em;
+    }
+
+    .scope {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      border: 1px solid var(--line);
+      background: var(--surface);
+    }
+
+    .scope-item {
+      min-width: 0;
+      padding: 18px 20px;
+      border-right: 1px solid var(--line);
+    }
+
+    .scope-item:last-child { border-right: 0; }
+
+    .scope-label {
+      display: block;
+      margin-bottom: 4px;
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 700;
+    }
+
+    .scope-value {
+      display: block;
+      font-size: 17px;
+      font-weight: 750;
+      overflow-wrap: anywhere;
+    }
+
+    .status {
+      display: inline-block;
+      padding: 2px 8px;
+      border: 1px solid currentColor;
+      border-radius: 4px;
+      font-size: 13px;
+      font-weight: 750;
+      white-space: nowrap;
+    }
+
+    .changed { color: var(--teal); background: var(--teal-soft); }
+    .unchanged { color: #334155; background: #f1f5f9; }
+
+    .table-wrap {
+      overflow-x: auto;
+      border: 1px solid var(--line);
+      background: var(--surface);
+    }
+
+    table {
+      width: 100%;
+      min-width: 690px;
+      border-collapse: collapse;
+    }
+
+    th,
+    td {
+      padding: 12px 14px;
+      border-bottom: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th {
+      color: #ffffff;
+      background: #27465f;
+      font-size: 14px;
+    }
+
+    tbody tr:last-child td { border-bottom: 0; }
+
+    .change-flow {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 44px minmax(0, 1fr);
+      align-items: stretch;
+      gap: 12px;
+    }
+
+    .flow-panel {
+      min-width: 0;
+      padding: 18px;
+      border: 1px solid var(--line);
+      border-top: 5px solid var(--red);
+      border-radius: 6px;
+      background: var(--surface);
+    }
+
+    .flow-panel.after { border-top-color: var(--teal); }
+
+    .flow-label {
+      display: inline-block;
+      margin-bottom: 10px;
+      padding: 2px 8px;
+      border-radius: 4px;
+      color: var(--red);
+      background: var(--red-soft);
+      font-size: 13px;
+      font-weight: 750;
+    }
+
+    .after .flow-label { color: var(--teal); background: var(--teal-soft); }
+
+    .arrow {
+      display: grid;
+      place-items: center;
+      color: var(--teal);
+      font-size: 30px;
+      font-weight: 800;
+    }
+
+    pre {
+      margin: 0;
+      padding: 15px;
+      overflow-x: auto;
+      border-radius: 5px;
+      color: #f8fafc;
+      background: var(--code);
+      font: 14px/1.65 Consolas, "Courier New", monospace;
+      tab-size: 4;
+    }
+
+    .sequence {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+      margin-top: 16px;
+      counter-reset: step;
+    }
+
+    .sequence div {
+      position: relative;
+      min-width: 0;
+      padding: 42px 14px 14px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: var(--surface);
+      overflow-wrap: anywhere;
+    }
+
+    .sequence div::before {
+      counter-increment: step;
+      content: counter(step);
+      position: absolute;
+      top: 11px;
+      left: 14px;
+      width: 23px;
+      height: 23px;
+      border-radius: 50%;
+      color: #ffffff;
+      background: var(--teal);
+      font: 700 13px/23px system-ui, sans-serif;
+      text-align: center;
+    }
+
+    .impact {
+      padding: 16px 18px;
+      border-left: 5px solid var(--amber);
+      background: var(--amber-soft);
+      color: #3b2a0b;
+    }
+
+    .impact strong { color: #4f3000; }
+
+    .compact-list {
+      margin: 0;
+      padding-left: 22px;
+    }
+
+    .compact-list li { margin-bottom: 7px; }
+
+    .compact-list li:last-child { margin-bottom: 0; }
+
+    footer {
+      padding: 18px 0 28px;
+      color: var(--muted);
+      border-top: 1px solid var(--line);
+      font-size: 13px;
+    }
+
+    @media (max-width: 760px) {
+      .header-inner,
+      main { width: min(100% - 24px, 1080px); }
+
+      .header-inner { padding: 26px 0 23px; }
+      h1 { font-size: 25px; }
+
+      .scope { grid-template-columns: 1fr; }
+      .scope-item { border-right: 0; border-bottom: 1px solid var(--line); }
+      .scope-item:last-child { border-bottom: 0; }
+
+      .change-flow { grid-template-columns: 1fr; }
+      .arrow { min-height: 34px; transform: rotate(90deg); }
+      .sequence { grid-template-columns: 1fr; }
+
+      .table-wrap {
+        overflow: visible;
+        border: 0;
+        background: transparent;
+      }
+
+      table,
+      tbody,
+      tr,
+      td { display: block; }
+
+      table { min-width: 0; }
+
+      thead {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      tbody tr {
+        margin-bottom: 12px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: var(--surface);
+      }
+
+      td {
+        display: block;
+        padding: 11px 13px;
+        overflow-wrap: anywhere;
+      }
+
+      td::before {
+        content: attr(data-label);
+        display: block;
+        margin-bottom: 4px;
+        color: var(--muted);
+        font-size: 13px;
+        font-weight: 750;
+      }
+
+      tbody tr:last-child td { border-bottom: 1px solid var(--line); }
+      tbody tr td:last-child { border-bottom: 0; }
+    }
+
+    @media (max-width: 430px) {
+      body { font-size: 15px; }
+      h1 { font-size: 23px; }
+      h2 { font-size: 19px; }
+      pre { font-size: 12px; }
+    }
+
+    @media print {
+      body { background: #ffffff; }
+      header { background: #ffffff; color: #000000; border-bottom-color: #000000; }
+      .subtitle { color: #222222; }
+      main { width: 100%; }
+      .table-wrap { overflow: visible; }
+      pre { white-space: pre-wrap; color: #000000; background: #f1f5f9; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="header-inner">
+      <h1>check 目录追加修改说明</h1>
+      <p class="subtitle">只记录在用户第二次手工修改版本之上继续调整的内容。</p>
+    </div>
+  </header>
+
+  <main>
+    <section aria-labelledby="scope-title">
+      <h2 id="scope-title">范围结论</h2>
+      <div class="scope">
+        <div class="scope-item">
+          <span class="scope-label">追加修改文件</span>
+          <span class="scope-value">1 个：<code>gnb_hash32.c</code></span>
+        </div>
+        <div class="scope-item">
+          <span class="scope-label">行为性修正</span>
+          <span class="scope-value">1 处：变长值节点替换</span>
+        </div>
+        <div class="scope-item">
+          <span class="scope-label">其余源文件</span>
+          <span class="scope-value">3 个：未再修改</span>
+        </div>
+      </div>
+    </section>
+
+    <section aria-labelledby="files-title">
+      <h2 id="files-title">逐文件说明</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>check 文件</th>
+              <th>状态</th>
+              <th>在手工版本之上的追加动作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td data-label="check 文件"><code>check/gnb_hash32.c</code></td>
+              <td data-label="状态"><span class="status changed">已修改</span></td>
+              <td data-label="追加动作">修正同 key、不同 value 长度时的链表节点替换顺序；同时统一 <code>if ( NULL == kv )</code> 的书写格式。</td>
+            </tr>
+            <tr>
+              <td data-label="check 文件"><code>check/gnb_alloc.c</code></td>
+              <td data-label="状态"><span class="status unchanged">未修改</span></td>
+              <td data-label="追加动作">手工版本中的最后 fragment 计数归零逻辑直接保留，没有追加代码调整。</td>
+            </tr>
+            <tr>
+              <td data-label="check 文件"><code>check/gnb_hash32.h</code></td>
+              <td data-label="状态"><span class="status unchanged">未修改</span></td>
+              <td data-label="追加动作">没有接口或声明层面的追加修改。</td>
+            </tr>
+            <tr>
+              <td data-label="check 文件"><code>check/gnb_alloc.h</code></td>
+              <td data-label="状态"><span class="status unchanged">未修改</span></td>
+              <td data-label="追加动作">没有接口或声明层面的追加修改。</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section aria-labelledby="core-title">
+      <h2 id="core-title">唯一的行为性修正</h2>
+      <p>修正位置是 <code>gnb_hash32_store()</code> 中“找到相同 key，但新旧 value 长度不同”的分支。</p>
+
+      <div class="change-flow">
+        <article class="flow-panel">
+          <span class="flow-label">手工版本的问题顺序</span>
+          <h3>先改链表入口，再计算新节点后继</h3>
+          <pre><code>重连前驱或 bucket 头节点
+kv-&gt;nex = bucket-&gt;kv_chain-&gt;nex;
+释放旧节点</code></pre>
+        </article>
+
+        <div class="arrow" aria-hidden="true">→</div>
+
+        <article class="flow-panel after">
+          <span class="flow-label">追加修正后的顺序</span>
+          <h3>先保存旧节点后继，再替换链表入口</h3>
+          <pre><code>kv-&gt;nex = kv_chain-&gt;nex;
+重连前驱或 bucket 头节点
+释放旧节点</code></pre>
+        </article>
+      </div>
+
+      <div class="sequence" aria-label="安全替换顺序">
+        <div>创建并检查新节点 <code>kv</code></div>
+        <div>保存旧节点的 <code>kv_chain-&gt;nex</code></div>
+        <div>把前驱或 bucket 头节点改接到 <code>kv</code></div>
+        <div>最后释放旧节点 <code>kv_chain</code></div>
+      </div>
+    </section>
+
+    <section aria-labelledby="reason-title">
+      <h2 id="reason-title">为什么需要这一步</h2>
+      <div class="impact">
+        <strong>核心问题：</strong>如果先把 <code>bucket-&gt;kv_chain</code> 或前驱节点改成新节点，再从已经变化的链表入口读取后继，新节点可能指向自身，或者丢失旧节点后面的碰撞链。先读取 <code>kv_chain-&gt;nex</code>，可以让头部、中部和尾部替换都保留原有后继关系。
+      </div>
+    </section>
+
+    <section aria-labelledby="non-code-title">
+      <h2 id="non-code-title">非代码动作</h2>
+      <ul class="compact-list">
+        <li>为保存修正，解除了 <code>check/gnb_hash32.c</code> 的只读属性。</li>
+        <li>该属性调整不改变编译结果和运行逻辑。</li>
+        <li>除此之外，没有在其他 <code>check/</code> 源文件上追加内容。</li>
+      </ul>
+    </section>
+
+    <footer>
+      本页只描述 check 手工版本之后的追加修改，不包含其他变更内容。
+    </footer>
+  </main>
+</body>
+</html>

--- a/src/gnb_alloc.c
+++ b/src/gnb_alloc.c
@@ -100,16 +100,18 @@ void gnb_heap_free(gnb_heap_t *gnb_heap, void *p){
         //发生错误了
         return;
     }
-
-    gnb_heap->alloc_byte -= fragment->size;
-    gnb_heap->ralloc_byte -= (sizeof(gnb_heap_fragment_t)+fragment->size);
-
     if ( last_fragment->idx != fragment->idx ) {
         last_fragment->idx = fragment->idx;
         gnb_heap->fragment_list[last_fragment->idx] = last_fragment;
     }
-
     gnb_heap->fragment_nums--;
+    if ( 0 != gnb_heap->fragment_nums ) {
+        gnb_heap->alloc_byte -= fragment->size;
+        gnb_heap->ralloc_byte -= (sizeof(gnb_heap_fragment_t)+fragment->size);
+    } else {
+        gnb_heap->alloc_byte = 0;
+        gnb_heap->ralloc_byte = 0;
+    }
     free(fragment);
 }
 

--- a/src/gnb_hash32.c
+++ b/src/gnb_hash32.c
@@ -154,17 +154,39 @@ int gnb_hash32_store(gnb_hash32_map_t *hash32_map, u_char *key, uint32_t key_len
     gnb_kv32_t *pre_kv_chain = kv_chain;
     do {
         if ( key_len != kv_chain->key->size ) {
+            //key长度不一致,key不一致,跳过
             pre_kv_chain = kv_chain;
             kv_chain = kv_chain->nex;
             continue;
         }
-        if ( !memcmp(kv_chain->key->data, key, key_len) ) {
+        if ( memcmp(kv_chain->key->data, key, key_len) ) {
+            //这里 输入的 key_len 与 kv_chain->key->size 一致,但key不一致,跳过
+            pre_kv_chain = kv_chain;
+            kv_chain = kv_chain->nex;
+            continue;
+        }
+        //到这里 key 与 kv_chain 里的 key 一致
+        if ( value_len == kv_chain->value->size ) {
+            //如果碰巧存入的 value 与 kv_chain->value 长度一致
+            //那么直接覆盖 kv_chain->value->data 就可以了
+            if ( 0 != value_len ) {
+                memcpy(kv_chain->value->data, value, value_len);
+            } else {
+                GNB_BLOCK_VOID(kv_chain->value) = value;
+            }
+            //存下当前的 kv ,标记为找到 key 对应的value
+            kv = kv_chain;
+            break;
+        } else {
+            //虽然 key 相同,但与原 value 存储的长度不一致
+            //先重新创建一个 kv,然后释放原来的 kv,
             kv = gnb_kv32_create(hash32_map, key, key_len, value, value_len);
             if ( NULL == kv ) {
                 return -1;
             }
             kv->nex = kv_chain->nex;
             if ( bucket->kv_chain != kv_chain ) {
+                //当 kv_chain 不是 bucket 的第一个kv
                 pre_kv_chain->nex = kv;
             } else {
                 bucket->kv_chain = kv;
@@ -172,10 +194,8 @@ int gnb_hash32_store(gnb_hash32_map_t *hash32_map, u_char *key, uint32_t key_len
             gnb_kv32_release(hash32_map, kv_chain);
             break;
         }
-        pre_kv_chain = kv_chain;
-        kv_chain = kv_chain->nex;
     } while (kv_chain);
-
+    //到这里,没有在 bucket 的 kv_chain 里找到对应输入的 key,那么创建一个kv,放在 kv_chain 的尾部
     if ( NULL == kv ) {
         pre_kv_chain->nex = gnb_kv32_create(hash32_map, key, key_len, value, value_len);
         bucket->chain_len++;


### PR DESCRIPTION
## 摘要

Hash32 对已存在 key 的更新现在会保留完整碰撞链：同长度值原地覆盖，变长值先完成新节点分配和接链，再释放旧节点；分配失败时旧值和链表保持不变。heap 释放最后一个 fragment 后会明确将 `alloc_byte` 和 `ralloc_byte` 归零，避免残余记账值继续暴露给调用方。

本次不改变公开接口、协议或 heap 的单线程使用约束。主要风险集中在 Hash32 碰撞链的节点替换顺序和 heap 计数更新顺序，已通过头、中、尾节点替换及分配失败场景验证。

关联 Issue：无。

## 验证

- Windows / MSYS2 MINGW64：`make -f Makefile.mingw_x86_64 clean`
- Windows / MSYS2 MINGW64：`make -f Makefile.mingw_x86_64 DEBUG=1 CC=gcc WINDRES=windres`
- Windows：`$env:__COMPAT_LAYER='RunAsInvoker'; .\gnb.exe --help`
- WSL Ubuntu：`make -f Makefile.linux clean`
- WSL Ubuntu：`make -f Makefile.linux DEBUG=1`
- WSL Ubuntu：`./gnb --help`
- 临时 C 回归探针在 MinGW 和 WSL 下均通过 7 个场景：最后 fragment 计数归零、同长度普通值更新、零长度指针更新、碰撞链头/中/尾变长替换、分配失败保留旧节点与旧值。

运行结果：两平台完整构建和 `--help` smoke 均成功；临时探针全部输出 `PASS`。分配失败注入场景出现预期日志 `gnb_heap_alloc fail heap is full`，其他场景无异常日志。仓库当前没有自动化测试框架，因此临时探针未纳入本次提交。

## Post-Deploy Monitoring & Validation

- 健康信号：Hash32 碰撞 key 均可正常读取，值长度和内容符合最后一次写入；heap 生命周期结束后 `fragment_nums`、`alloc_byte`、`ralloc_byte` 均为 `0`。
- 失败信号：Hash32 查询卡住或高 CPU、碰撞 key 丢失、heap 清理后计数非零，或非故障注入情况下出现 `gnb_heap_alloc fail heap is full`。
- 验证窗口：合并后的下一次启动与配置加载流程，并持续观察 24 小时；由维护者确认日志和运行状态。
- 回滚方式：回退本 PR 的两个提交；无数据迁移、配置迁移或协议兼容处理。

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
